### PR TITLE
EPT-32 - Automate linking

### DIFF
--- a/_data/sitemap-apps.yml
+++ b/_data/sitemap-apps.yml
@@ -46,6 +46,9 @@
 - key: api-rest
   title: API reference
   entries:
+    - title: All resources
+      link: page:api-resources-all
+
     - title: Carts
       link: page:api-resources-carts
 
@@ -55,14 +58,14 @@
     - title: Legal
       link: page:api-resources-legal
 
+    - title: Miscellaneous
+      link: page:api-resources-miscellaneous
+
     - title: Products
       link: page:api-resources-products
 
     - title: ShippingMethods
       link: page:api-resources-shipping-methods
-
-    - title: All resources
-      link: page:api-resources-all
 
 - key: more
   title: More

--- a/apps/api-reference/resource-miscellaneous.md
+++ b/apps/api-reference/resource-miscellaneous.md
@@ -1,0 +1,18 @@
+---
+layout: page
+key: api-resources-miscellaneous
+title: Miscellaneous
+---
+<ul id="resource-list">
+  {% for page in site.pages %}
+  {% assign misc = "" | split: ' ' %}
+    {% for category in misc %}
+      {% if page.raml_resource.relative_uri contains category %}
+        <li class="resource-entry">
+          <span class="http-method http-method-{{ page.raml_method.method | downcase }}">{{ page.raml_method.method }}</span>
+          <a href="{{ page.url | prepend: site.baseurl }}">{{ page.raml_resource.relative_uri }}</a>
+        </li>
+      {% endif %}
+    {% endfor %}
+  {% endfor %}
+</ul>


### PR DESCRIPTION
Created a new rake task that allows to automate the addition of new API resources.
This task can be called using **rake resource** and needs as argument the new resources.
The arguments can be:
 *  `new` : to add a new category related with the resource indicated as a parameter.Internally, the task:
   * Update the file `sitemap-apps` with the new category
   * Create the proper template `resource-category` in the folder `api-reference`
 *  `misc` : to add a new references into the miscellaneous category. Internally, the task:
   * Update the `miscellaneous.raml` with the new category
   * Update the `resource-miscellaneous.md` with the new category
The argument passed must be **the folder** in `_raml/apps` that includes the new category resources.

Also, the task admit a list of resources joined by `,` and both arguments can be accepted at the same time.
 
### Example
`rake resource new=cart,order misc=start-page,appstore`