### PR TITLE
EPT-23 - Display resource properties

### DIFF
--- a/_layouts/resource.html
+++ b/_layouts/resource.html
@@ -104,6 +104,37 @@ layout: page
       {% if body.example %}
         <pre class="pre-scrollable">{{ body.example }}</pre>
       {% endif %}
+      {% if body.schema != null %}
+        <h2>Response Attributes</h2>
+        <table class="table table-bordered">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Type</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+          {% assign keys = body.schema | json_keys: 'properties' %}
+          {% assign properties = body.schema | json_field: 'properties' %}
+          {% for key in keys %}
+            {% assign p = properties[key] %}
+            <tr>
+              <td><code>{{ key }}</code></td>
+              <td><strong>{{ p.type }}</strong></td>
+              <td>
+                {% if p.description %}<div>Description: {{ p.description | markdownify }}</div>{% endif %}
+                <div>Required: <code>{{ p.required }}</code></div>
+                {% if p.example %}<div>Example: <code>{{ p.example }}</code></div>{% endif %}
+                {% if p.default %}<div>Default: <code>{{ p.default }}</code></div>{% endif %}
+                {% if p.minimum %}<div>Minimum: {{ p.minimum }}</div>{% endif %}
+                {% if p.maximum %}<div>Maximum: {{ p.maximum }}</div>{% endif %}
+              </td>
+            </tr>
+          {% endfor %}
+          </tbody>
+        </table>
+      {% endif %}
     {% endfor %}
   {% endfor %}
 {% endif %}

--- a/_layouts/resource.html
+++ b/_layouts/resource.html
@@ -21,7 +21,7 @@ layout: page
     <tr>
       <th>Name</th>
       <th>Type</th>
-      <th></th>
+      <th>Description</th>
     </tr>
     </thead>
     <tbody>
@@ -31,7 +31,7 @@ layout: page
         <td><code>{{ p.name. }}</code></td>
         <td><strong>{{ p.type. }}</strong></td>
         <td>
-          {% if p.description %}<div>Description: {{ p.description | markdownify }}</div>{% endif %}
+          {% if p.description %}<div>{{ p.description | markdownify }}</div>{% endif %}
           <div>Required: <code>{{ p.required }}</code></div>
           {% if p.example %}<div>Example: <code>{{ p.example }}</code></div>{% endif %}
           {% if p.default %}<div>Default: <code>{{ p.default }}</code></div>{% endif %}
@@ -53,7 +53,7 @@ layout: page
     <tr>
       <th>Name</th>
       <th>Type</th>
-      <th></th>
+      <th>Description</th>
     </tr>
     </thead>
     <tbody>
@@ -63,7 +63,7 @@ layout: page
         <td><code>{{ p.name. }}</code></td>
         <td><strong>{{ p.type. }}</strong></td>
         <td>
-          {% if p.description %}<div>Description: {{ p.description | markdownify }}</div>{% endif %}
+          {% if p.description %}<div>{{ p.description | markdownify }}</div>{% endif %}
           <div>Required: <code>{{ p.required }}</code></div>
           {% if p.example %}<div>Example: <code>{{ p.example }}</code></div>{% endif %}
           {% if p.default %}<div>Default: <code>{{ p.default }}</code></div>{% endif %}
@@ -106,12 +106,11 @@ layout: page
       {% endif %}
       {% if body.schema != null %}
         <h2>Response Attributes</h2>
-        <table class="table table-bordered">
-          <thead>
+        <table class="table table-bordered table-striped">
+          <thead style="background-color: white;">
             <tr>
               <th>Name</th>
-              <th>Type</th>
-              <th></th>
+              <th>Description</th>
             </tr>
           </thead>
           <tbody>
@@ -121,14 +120,8 @@ layout: page
             {% assign p = properties[key] %}
             <tr>
               <td><code>{{ key }}</code></td>
-              <td><strong>{{ p.type }}</strong></td>
               <td>
-                {% if p.description %}<div>Description: {{ p.description | markdownify }}</div>{% endif %}
-                <div>Required: <code>{{ p.required }}</code></div>
-                {% if p.example %}<div>Example: <code>{{ p.example }}</code></div>{% endif %}
-                {% if p.default %}<div>Default: <code>{{ p.default }}</code></div>{% endif %}
-                {% if p.minimum %}<div>Minimum: {{ p.minimum }}</div>{% endif %}
-                {% if p.maximum %}<div>Maximum: {{ p.maximum }}</div>{% endif %}
+                {% if p.description %}<div>{{ p.description | markdownify }}</div>{% endif %}
               </td>
             </tr>
           {% endfor %}

--- a/_plugins/json.rb
+++ b/_plugins/json.rb
@@ -1,0 +1,16 @@
+require 'json'
+
+module Jekyll
+  module JsonFilter
+    # return the key names (one level deep) inside the property attribute
+    def json_keys(input, property)
+      JSON.parse(input)[property].keys unless input.nil?
+    end
+
+    #return the value of property attribute related to input
+    def json_field(input, property)
+      JSON.parse(input)[property] unless input.nil?
+    end
+  end
+end
+Liquid::Template.register_filter(Jekyll::JsonFilter)


### PR DESCRIPTION
Raml File: In order to add the response resource properties table, is necessary to add the attribute `schema` to indicate the schema related:
`schema: !include schema_name.schema.json`
### Example raml file:
```
responses:
      200:
        body:
          application/json:
            schema: !include product.schema.json
            example: !include get_product_response.json
```

JSON schema: in this first interaction, the target is display the responses attributes in the API documentation. For this reason the json schema is simple version that **not validates the correctness of the file**. In order to display the properties in the front-end, it's necessary add the attribute `properties` that includes all the list of the attributes we want to show.
### Example JSON schema
```json
{
  "$schema": "http://json-schema.org/draft-03/schema",
  "title": "Product Schema",
  "type": "object",
  "properties": {
    "property1": {
      "type": "string",
      "description": "description test",
      "required": true
    },
    "property2": {
      "type": "string",
      "required": true
    }
  }
}
```
