### PR TITLE
Update product related details

### DIFF
--- a/_raml/apps/products/examples/get_product_productid_response.json
+++ b/_raml/apps/products/examples/get_product_productid_response.json
@@ -2,6 +2,12 @@
   "productId": "51E7F905-2E4C-78C2-30C2-AC14145FA4E5",
   "name": "Dr.Boom - Red Power",
   "visible": true,
+  "productVariationType": "regular",
+  "manufacturerProductNumber": "HP-003",
+  "productLength": null,
+  "productWidth": null,
+  "productHeight": null,
+  "productVariationSelection": null,
   "shortDescription": "<p>Red Resonator S&nbsp;headphones are the best-performing around-ear headphones from&nbsp;Dr.Boom. They give you fresh and&nbsp;powerful sound.&nbsp;These headphones definitely&nbsp;let you hear your music better!</p>",
   "deliveryPeriod": "3-5",
   "description": "<p><strong><em>Dr.Boom - HP001</em></strong>&nbsp;Red Resonator S&nbsp;headphones are the best-performing around-ear headphones from&nbsp;Dr.Boom. They give you fresh and&nbsp;powerful sound.&nbsp;These headphones definitely&nbsp;let you hear your music better!</p>\r\n\r\n<p>The noise cancelling technology monitors the noise around you and cancels it out, helping you focus on what you want to hear -&nbsp;whether it’s music, calls or simply peace and quiet. These headphones look as good as they sound. They’re comfy, durably made and easily to store, with earcups that&nbsp;fit in a small carrying box.</p>",
@@ -79,6 +85,7 @@
     "Correct fit"
   ],
   "stocklevel": 100,
+  "minStocklevel": 10,
   "links": [
     {
       "rel": "self",

--- a/_raml/apps/products/examples/get_product_response.json
+++ b/_raml/apps/products/examples/get_product_response.json
@@ -7,6 +7,12 @@
       "productId": "54EF2E41-FCA8-E0E5-9323-0A0C05E66C2E",
       "name": "Customised headphone",
       "visible": true,
+      "productVariationType": "regular",
+      "manufacturerProductNumber": "CU001",
+      "productLength": null,
+      "productWidth": null,
+      "productHeight": null,
+      "productVariationSelection": null,
       "shortDescription": null,
       "deliveryPeriod": "2-4",
       "description": "Customise your headphone in no time!",
@@ -41,20 +47,20 @@
         "taxClass": {
           "taxClassId": "54B50D97-A277-9AF2-58A1-D5809AB32230",
           "name": "standard",
-          "percentage": null
+          "percentage": 19
         },
         "price": {
-          "taxType": "GROSS",
-          "formatted": "299.00 €",
-          "amount": 299,
+          "taxType": "NET",
+          "formatted": "251.26 €",
+          "amount": 251.26,
           "currency": "EUR"
         },
         "depositPrice": null,
         "ecoParticipationPrice": null,
         "priceWithDeposits": {
-          "taxType": "GROSS",
-          "formatted": "299.00 €",
-          "amount": 299,
+          "taxType": "NET",
+          "formatted": "251.26 €",
+          "amount": 251.26,
           "currency": "EUR"
         },
         "manufacturerPrice": null,
@@ -76,19 +82,18 @@
       "manufacturer": "Dr. Boom",
       "upc": null,
       "ean": null,
-      "essentialFeature": null,
+      "essentialFeatures": null,
+      "searchKeywords": [],
+      "stocklevel": null,
+      "minStocklevel": null,
       "links": [
         {
           "rel": "self",
           "href": "https://pm.epages.com/rs/shops/apidocu/products/54EF2E41-FCA8-E0E5-9323-0A0C05E66C2E"
         },
         {
-          "rel": "custom-attributes",
-          "href": "https://pm.epages.com/rs/shops/apidocu/products/54EF2E41-FCA8-E0E5-9323-0A0C05E66C2E/custom-attributes"
-        },
-        {
           "rel": "categories",
-          "href": "https://pm.epages.com/rs/shops/apidocu/products/54EF2E41-FCA8-E0E5-9323-0A0C05E66C2E/categories"
+          "href": "https://pm.epages.com/rs/shops/apidocu/categories/?productId=54EF2E41-FCA8-E0E5-9323-0A0C05E66C2E"
         }
       ]
     },
@@ -96,6 +101,12 @@
       "productId": "51E7F905-2E4C-78C2-30C2-AC14145FA4E5",
       "name": "Dr.Boom - Red Power",
       "visible": true,
+      "productVariationType": "regular",
+      "manufacturerProductNumber": "HP-003",
+      "productLength": null,
+      "productWidth": null,
+      "productHeight": null,
+      "productVariationSelection": null,
       "shortDescription": "<p>Red Resonator S&nbsp;headphones are the best-performing around-ear headphones from&nbsp;Dr.Boom. They give you fresh and&nbsp;powerful sound.&nbsp;These headphones definitely&nbsp;let you hear your music better!</p>",
       "deliveryPeriod": "3-5",
       "description": "<p><strong><em>Dr.Boom - HP001</em></strong>&nbsp;Red Resonator S&nbsp;headphones are the best-performing around-ear headphones from&nbsp;Dr.Boom. They give you fresh and&nbsp;powerful sound.&nbsp;These headphones definitely&nbsp;let you hear your music better!</p>\r\n\r\n<p>The noise cancelling technology monitors the noise around you and cancels it out, helping you focus on what you want to hear -&nbsp;whether it’s music, calls or simply peace and quiet. These headphones look as good as they sound. They’re comfy, durably made and easily to store, with earcups that&nbsp;fit in a small carrying box.</p>",
@@ -132,17 +143,17 @@
           "percentage": 19
         },
         "price": {
-          "taxType": "GROSS",
-          "formatted": "65.00 €",
-          "amount": 65,
+          "taxType": "NET",
+          "formatted": "54.62 €",
+          "amount": 54.62,
           "currency": "EUR"
         },
         "depositPrice": null,
         "ecoParticipationPrice": null,
         "priceWithDeposits": {
-          "taxType": "GROSS",
-          "formatted": "65.00 €",
-          "amount": 65,
+          "taxType": "NET",
+          "formatted": "54.62 €",
+          "amount": 54.62,
           "currency": "EUR"
         },
         "manufacturerPrice": null,
@@ -170,19 +181,16 @@
         "Acoustic Noise Cancelling",
         "Correct fit"
       ],
-      "stocklevel": 99,
+      "stocklevel": 100,
+      "minStocklevel": 10,
       "links": [
         {
           "rel": "self",
           "href": "https://pm.epages.com/rs/shops/apidocu/products/51E7F905-2E4C-78C2-30C2-AC14145FA4E5"
         },
         {
-          "rel": "custom-attributes",
-          "href": "https://pm.epages.com/rs/shops/apidocu/products/51E7F905-2E4C-78C2-30C2-AC14145FA4E5/custom-attributes"
-        },
-        {
           "rel": "categories",
-          "href": "https://pm.epages.com/rs/shops/apidocu/products/51E7F905-2E4C-78C2-30C2-AC14145FA4E5/categories"
+          "href": "https://pm.epages.com/rs/shops/apidocu/categories/?productId=51E7F905-2E4C-78C2-30C2-AC14145FA4E5"
         }
       ]
     },
@@ -190,6 +198,12 @@
       "productId": "51E7F913-5447-240E-77AE-AC14145FA477",
       "name": "Dr.Boom - True Voice",
       "visible": true,
+      "productVariationType": "master",
+      "manufacturerProductNumber": "HS-001",
+      "productLength": null,
+      "productWidth": null,
+      "productHeight": null,
+      "productVariationSelection": null,
       "shortDescription": null,
       "deliveryPeriod": "3-5",
       "description": "Professional headphones. Bass pipe emphasises low tones for a clear, realistic sound. Ergonomically shaped.",
@@ -227,24 +241,24 @@
           "percentage": 19
         },
         "price": {
-          "taxType": "GROSS",
-          "formatted": "149.99 €",
-          "amount": 149.99,
+          "taxType": "NET",
+          "formatted": "126.04 €",
+          "amount": 126.04,
           "currency": "EUR"
         },
         "depositPrice": null,
         "ecoParticipationPrice": null,
         "priceWithDeposits": {
-          "taxType": "GROSS",
-          "formatted": "149.99 €",
-          "amount": 149.99,
+          "taxType": "NET",
+          "formatted": "42.02 €",
+          "amount": 42.02,
           "currency": "EUR"
         },
         "manufacturerPrice": null,
         "basePrice": null
       },
-      "forSale": true,
-      "specialOffer": false,
+      "forSale": false,
+      "specialOffer": true,
       "deliveryWeight": {
         "amount": 310,
         "unit": "g"
@@ -264,18 +278,20 @@
         "Surround Sound",
         "Bluetooth Wireless"
       ],
+      "stocklevel": 100,
+      "minStocklevel": 10,
       "links": [
         {
           "rel": "self",
           "href": "https://pm.epages.com/rs/shops/apidocu/products/51E7F913-5447-240E-77AE-AC14145FA477"
         },
         {
-          "rel": "custom-attributes",
-          "href": "https://pm.epages.com/rs/shops/apidocu/products/51E7F913-5447-240E-77AE-AC14145FA477/custom-attributes"
+          "rel": "variations",
+          "href": "https://pm.epages.com/rs/shops/apidocu/products/51E7F913-5447-240E-77AE-AC14145FA477/variations"
         },
         {
           "rel": "categories",
-          "href": "https://pm.epages.com/rs/shops/apidocu/products/51E7F913-5447-240E-77AE-AC14145FA477/categories"
+          "href": "https://pm.epages.com/rs/shops/apidocu/categories/?productId=51E7F913-5447-240E-77AE-AC14145FA477"
         }
       ]
     }

--- a/_raml/apps/products/examples/get_product_updated_property_response.json
+++ b/_raml/apps/products/examples/get_product_updated_property_response.json
@@ -8,10 +8,15 @@
         "productId": "51E7F905-2E4C-78C2-30C2-AC14145FA4E5",
         "name": "Dr.Boom - Red Power",
         "visible": true,
+        "productVariationType": "regular",
+        "manufacturerProductNumber": "HP-003",
+        "productLength": null,
+        "productWidth": null,
+        "productHeight": null,
+        "productVariationSelection": null,
         "shortDescription": "<p>Red Resonator S&nbsp;headphones are the best-performing around-ear headphones from&nbsp;Dr.Boom. They give you fresh and&nbsp;powerful sound.&nbsp;These headphones definitely&nbsp;let you hear your music better!</p>",
         "deliveryPeriod": "3-5",
         "description": "<p><strong><em>Dr.Boom - HP001</em></strong>&nbsp;Red Resonator S&nbsp;headphones are the best-performing around-ear headphones from&nbsp;Dr.Boom. They give you fresh and&nbsp;powerful sound.&nbsp;These headphones definitely&nbsp;let you hear your music better!</p>\r\n\r\n<p>The noise cancelling technology monitors the noise around you and cancels it out, helping you focus on what you want to hear -&nbsp;whether it’s music, calls or simply peace and quiet. These headphones look as good as they sound. They’re comfy, durably made and easily to store, with earcups that&nbsp;fit in a small carrying box.</p>",
-        "productImage": "013-headphone-red.jpg",
         "images": [
           {
             "url": "https://pm.epages.com/WebRoot/Store/Shops/apidocu/51E7/F905/2E4C/78C2/30C2/AC14/145F/A4E5/013-headphone-red_h.jpg",
@@ -45,32 +50,31 @@
             "percentage": 19
           },
           "price": {
-            "taxType": "GROSS",
-            "formatted": "65.00 €",
-            "amount": 65,
+            "taxType": "NET",
+            "formatted": "54.62 €",
+            "amount": 54.62,
             "currency": "EUR"
           },
           "depositPrice": null,
           "ecoParticipationPrice": null,
           "priceWithDeposits": {
-            "taxType": "GROSS",
-            "formatted": "65.00 €",
-            "amount": 65,
+            "taxType": "NET",
+            "formatted": "54.62 €",
+            "amount": 54.62,
             "currency": "EUR"
           },
           "manufacturerPrice": null,
           "basePrice": null
         },
         "forSale": true,
-        "specialOffer": true,
+        "specialOffer": false,
         "deliveryWeight": {
           "amount": 260,
           "unit": "g"
         },
-        "shippingMethodsRestrictedTo": null,
         "availabilityText": "In stock<br />can be shipped within 3-5 days",
         "availability": "OnStock",
-        "energyLabelsString": "A+++",
+        "energyLabelsString": null,
         "energyLabelSourceFile": null,
         "productDataSheet": null,
         "sfUrl": "http://pm.epages.com/epages/apidocu.sf/?ObjectPath=/Shops/apidocu/Products/HP-003",
@@ -85,23 +89,15 @@
           "Correct fit"
         ],
         "stocklevel": 100,
+        "minStocklevel": 10,
         "links": [
           {
             "rel": "self",
             "href": "https://pm.epages.com/rs/shops/apidocu/products/51E7F905-2E4C-78C2-30C2-AC14145FA4E5"
           },
           {
-            "rel": "custom-attributes",
-            "href": "https://pm.epages.com/rs/shops/apidocu/products/51E7F905-2E4C-78C2-30C2-AC14145FA4E5/custom-attributes"
-          },
-          {
             "rel": "categories",
-            "href": "https://pm.epages.com/rs/shops/apidocu/products/51E7F905-2E4C-78C2-30C2-AC14145FA4E5/categories"
-          },
-          {
-            "rel": "main-category",
-            "href": "https://pm.epages.com/rs/shops/apidocu/categories/546E02D6-3469-4610-54A1-0A0C05E63C68",
-            "title": "On-Ear"
+            "href": "https://pm.epages.com/rs/shops/apidocu/categories/?productId=51E7F905-2E4C-78C2-30C2-AC14145FA4E5"
           }
         ]
       },

--- a/_raml/apps/products/examples/patch_product_productid_response.json
+++ b/_raml/apps/products/examples/patch_product_productid_response.json
@@ -2,6 +2,12 @@
   "productId": "51E7F905-2E4C-78C2-30C2-AC14145FA4E5",
   "name": "BRAND NEW: Dr.Boom - Star Wars Edition",
   "visible": true,
+  "productVariationType": "regular",
+  "manufacturerProductNumber": "HP-003",
+  "productLength": null,
+  "productWidth": null,
+  "productHeight": null,
+  "productVariationSelection": null,
   "shortDescription": "new arrival",
   "description": "<ul>\n\t<li>Surround Sound</li>\n\t<li>Acoustic Noise Cancelling</li>\n\t<li>Correct fit",
   "productImage": "014-headphone-starwars.jpg",
@@ -37,16 +43,16 @@
       "percentage": 19
     },
     "price": {
-      "taxType": "GROSS",
-      "formatted": "65.00 €",
-      "amount": 65,
+      "taxType": "NET",
+      "formatted": "54.62 €",
+      "amount": 54.62,
       "currency": "EUR"
     },
     "depositPrice": null,
     "priceWithDeposits": {
-      "taxType": "GROSS",
-      "formatted": "65.00 €",
-      "amount": 65,
+      "taxType": "NET",
+      "formatted": "54.62 €",
+      "amount": 54.62,
       "currency": "EUR"
     },
     "manufacturerPrice": null,
@@ -74,19 +80,16 @@
     "Noise Cancelling",
     "Carrying Box"
   ],
-  "stocklevel": 2,
+  "stocklevel": 100,
+  "minStocklevel": 10,
   "links": [
     {
       "rel": "self",
       "href": "https://pm.epages.com/rs/shops/apidocu/products/51E7F905-2E4C-78C2-30C2-AC14145FA4E5"
     },
     {
-      "rel": "custom-attributes",
-      "href": "https://pm.epages.com/rs/shops/apidocu/products/51E7F905-2E4C-78C2-30C2-AC14145FA4E5/custom-attributes"
-    },
-    {
       "rel": "categories",
-      "href": "https://pm.epages.com/rs/shops/apidocu/products/51E7F905-2E4C-78C2-30C2-AC14145FA4E5/categories"
+      "href": "https://pm.epages.com/rs/shops/apidocu/categories/?productId=51E7F905-2E4C-78C2-30C2-AC14145FA4E5"
     }
   ]
 }

--- a/_raml/apps/products/examples/patch_product_productid_response.json
+++ b/_raml/apps/products/examples/patch_product_productid_response.json
@@ -43,7 +43,6 @@
       "currency": "EUR"
     },
     "depositPrice": null,
-    "ecoParticipationPrice": null,
     "priceWithDeposits": {
       "taxType": "GROSS",
       "formatted": "65.00 €",
@@ -62,7 +61,6 @@
   "shippingMethodsRestrictedTo": null,
   "availabilityText": "In stock<br />can be shipped within 3-5 days",
   "availability": "OnStock",
-  "energyLabelsString": null,
   "energyLabelSourceFile": null,
   "productDataSheet": null,
   "sfUrl": "http://pm.epages.com/epages/apidocu.sf/?ObjectPath=/Shops/apidocu/Products/HP-003",

--- a/_raml/apps/products/examples/post_product_response.json
+++ b/_raml/apps/products/examples/post_product_response.json
@@ -1,8 +1,15 @@
 {
-  "productId": "5704DD36-CF73-2959-B830-D5809AB3F450",
-  "name": "Brand new product",
+  "productId": "57D647C1-77D5-DD52-3024-D5809AB3A134",
+  "name": "Next brand new product",
   "visible": false,
-  "shortDescription": "Awesome product",
+  "productVariationType": "regular",
+  "manufacturerProductNumber": null,
+  "productLength": null,
+  "productWidth": null,
+  "productHeight": null,
+  "productVariationSelection": null,
+  "shortDescription": "Awesome new product",
+  "deliveryPeriod": null,
   "description": "This is a brand new product",
   "productImage": null,
   "images": [],
@@ -17,31 +24,32 @@
       "percentage": 19
     },
     "price": {
-      "taxType": "GROSS",
-      "formatted": "5,99 €",
-      "amount": 5.99,
+      "taxType": "NET",
+      "formatted": "10.99 €",
+      "amount": 10.99,
       "currency": "EUR"
     },
     "depositPrice": null,
+    "ecoParticipationPrice": null,
     "priceWithDeposits": {
-      "taxType": "GROSS",
-      "formatted": "5,99 €",
-      "amount": 5.99,
+      "taxType": "NET",
+      "formatted": "10.99 €",
+      "amount": 10.99,
       "currency": "EUR"
     },
     "manufacturerPrice": null,
     "basePrice": null
   },
-  "forSale": true,
+  "forSale": false,
   "specialOffer": false,
   "deliveryWeight": null,
-  "shippingMethodsRestrictedTo": null,
   "availabilityText": "",
   "availability": null,
+  "energyLabelsString": null,
   "energyLabelSourceFile": null,
   "productDataSheet": null,
-  "sfUrl": "http://pm.epages.com/epages/apidocu.sf/?ObjectPath=/Shops/apidocu/Products/01234",
-  "productNumber": "01234",
+  "sfUrl": "http://pm.epages.com/epages/apidocu.sf/?ObjectPath=/Shops/apidocu/Products/TP-0821",
+  "productNumber": "TP-0821",
   "manufacturer": "Awesome Products Company",
   "upc": null,
   "ean": null,
@@ -51,18 +59,15 @@
     "product"
   ],
   "stocklevel": null,
+  "minStocklevel": null,
   "links": [
     {
       "rel": "self",
-      "href": "https://pm.epages.com/rs/shops/apidocu/products/5704DD36-CF73-2959-B830-D5809AB3F450"
-    },
-    {
-      "rel": "custom-attributes",
-      "href": "https://pm.epages.com/rs/shops/apidocu/products/5704DD36-CF73-2959-B830-D5809AB3F450/custom-attributes"
+      "href": "https://pm.epages.com/rs/shops/apidocu/products/57D647C1-77D5-DD52-3024-D5809AB3A134"
     },
     {
       "rel": "categories",
-      "href": "https://pm.epages.com/rs/shops/apidocu/products/5704DD36-CF73-2959-B830-D5809AB3F450/categories"
+      "href": "https://pm.epages.com/rs/shops/apidocu/categories/?productId=57D647C1-77D5-DD52-3024-D5809AB3A134"
     }
   ]
 }

--- a/_raml/apps/products/examples/post_product_response.json
+++ b/_raml/apps/products/examples/post_product_response.json
@@ -23,7 +23,6 @@
       "currency": "EUR"
     },
     "depositPrice": null,
-    "ecoParticipationPrice": null,
     "priceWithDeposits": {
       "taxType": "GROSS",
       "formatted": "5,99 €",
@@ -39,7 +38,6 @@
   "shippingMethodsRestrictedTo": null,
   "availabilityText": "",
   "availability": null,
-  "energyLabelsString": null,
   "energyLabelSourceFile": null,
   "productDataSheet": null,
   "sfUrl": "http://pm.epages.com/epages/apidocu.sf/?ObjectPath=/Shops/apidocu/Products/01234",

--- a/_raml/apps/products/products.raml
+++ b/_raml/apps/products/products.raml
@@ -61,7 +61,7 @@ post:
       example: 52F221E0-36F6-DC4E-384A-AC1504050C04
   get:
     description: Returns information on a single product. For product variations, a link
-      to the respective product variations resource (rel="variations") is added. Note that the attribute `stocklevel` is only available with the `products_write` authorisation.
+      to the respective product variations resource (rel="variations") is added.
     securedBy: [products_read]
     is: [ locale, currency ]
     responses:

--- a/_raml/apps/products/products.raml
+++ b/_raml/apps/products/products.raml
@@ -61,7 +61,7 @@ post:
       example: 52F221E0-36F6-DC4E-384A-AC1504050C04
   get:
     description: Returns information on a single product. For product variations, a link
-      to the respective product variations resource (rel="variations") is added.
+      to the respective product variations resource (rel="variations") is added. Note that the attribute `minStocklevel` is only available with the `products_write` authorisation.
     securedBy: [products_read]
     is: [ locale, currency ]
     responses:

--- a/apps/change-log.md
+++ b/apps/change-log.md
@@ -10,6 +10,25 @@ In order to keep track of these changes we recommend you to follow [@epagesdevs]
 
 <hr>
 
+## 2016-09-13
+
+### Changes with software release 6.17.52
+
+#### <i class="fa fa-pencil"></i> Update
+
+* Added response code [*410 Gone*](https://developer.epages.com/apps/response-codes#responses-in-the-4xx-range).
+* Required to set user agent in [request header](https://developer.epages.com/apps/request-headers).
+* Specified attributes `stocklevel`, `depositPrice`, `ecoParticipationPrice`, and `manufacturerPrice` for [`POST` products](https://developer.epages.com/apps/api-reference/post-shops-shopid-products.html).
+* Added attributes `manufacturerProductNumber`, `minStocklevel`, `productLength`, `productHeight`, `productWidth` `productVariationType`, and `productVariationSelection` to data type [`product`](https://developer.epages.com/apps/data-types#product).
+* Added data type [`variationIdentifier`](https://developer.epages.com/apps/data-types#variationidentifier).
+* Removed `products_write` authorisation from `stocklevel` attribute.
+
+#### <i class="fa fa-minus"></i> Remove
+
+* Removed attributes `energyLabelsString` and `ecoParticipationPrice` from [`POST` products](https://developer.epages.com/apps/api-reference/post-shops-shopid-products.html) and [`PATCH` products/{productId}](https://developer.epages.com/apps/api-reference/patch-shops-shopid-products-productid.html).
+
+<hr>
+
 ## 2016-08-25
 
 ### Changes with software release 6.17.51

--- a/apps/data-types.md
+++ b/apps/data-types.md
@@ -359,6 +359,10 @@ This object is used for the attributes of basePrice, depositPrice, ecoParticipat
 | ean | string | The European Article Number of the product, either EAN-8 or EAN-13. |
 | essentialFeatures | string | The essential features of the product. |
 | searchKeywords | array of strings | The search terms for the product determined by the merchant in the administration.  |
+| manufacturerProductNumber | string | The unique manufacturer identifier of the product. Used to identify and classify a product.  |
+| productLength | number| The length of the product in mm. |
+| productWidth | number | The width of the product in mm.  |
+| productHeight | number | The height of the product in mm.  |
 | stocklevel | number | Indicates the stock level of the product. |
 | minStocklevel | number | Indicates the minimum stock level of the product. Available if the field *Minimum stock level* is used in the administration area of a shop. Only available with the `products_write` authorisation. |
 | links | array of [link](page:apps-data-types#link) | The links to the product and product category. |

--- a/apps/data-types.md
+++ b/apps/data-types.md
@@ -215,7 +215,7 @@ This object is used for the attributes of shippingAddress and billingAddress.
 | lineItemsSubTotal | object of [price](page:apps-data-types#price) | The sum of the line item price of all line items. |
 | productLineItems | array of [productLineItem](page:apps-data-types#productlineitem) | A list of line items. |
 | shippingPrice | object of [price](page:apps-data-types#price) | The shipping price of the line item. |
-| couponLineItem | array of [couponLineItem](page:apps-data-types#couponlineitem) | Contains the line items of a coupon. |
+| couponLineItem | object of [couponLineItem](page:apps-data-types#couponlineitem) | Contains the line items of a coupon. |
 
 ## link
 
@@ -289,7 +289,6 @@ This object is used for the attributes of shippingAddress and billingAddress.
 | shippingData | object of [shippingData](page:apps-data-types#shippingdata) | The shipping data of  a cart or an order, i.e. short info on shipping method and price.|
 | paymentData | object of [paymentData](page:apps-data-types#paymentdata) | The payment data of  a cart or an order, i.e. short info on payment method and price.|
 | lineItemContainer | [lineItemContainer](page:apps-data-types#lineitemcontainer) | Contains the line items of an order. Only included in [`GET`/orders/{orderId}](page:apps-api-get-shops-shopid-orders-orderid-information). |
-| productLineItems | array of [productLineItem](page:apps-data-types#productlineitem) | A list of line items. Only included in [`GET`/orders/{orderId}](page:apps-api-get-shops-shopid-orders-orderid-information). |
 | shippingPrice | object of [price](page:apps-data-types#price) | The shipping price for the order.  |
 | links | array of [link](page:apps-data-types#link) | The links to the products of the order. |
 

--- a/apps/data-types.md
+++ b/apps/data-types.md
@@ -359,7 +359,8 @@ This object is used for the attributes of basePrice, depositPrice, ecoParticipat
 | ean | string | The European Article Number of the product, either EAN-8 or EAN-13. |
 | essentialFeatures | string | The essential features of the product. |
 | searchKeywords | array of strings | The search terms for the product determined by the merchant in the administration.  |
-| stocklevel | string | Only available with the `products_write` authorisation. Indicates the stocklevel of the product. |
+| stocklevel | number | Indicates the stock level of the product. |
+| minStocklevel | number | Indicates the minimum stock level of the product. Available if the field *Minimum stock level* is used in the administration area of a shop. Only available with the `products_write` authorisation. |
 | links | array of [link](page:apps-data-types#link) | The links to the product and product category. |
 
 ## product (create request)

--- a/apps/data-types.md
+++ b/apps/data-types.md
@@ -366,6 +366,8 @@ This object is used for the attributes of basePrice, depositPrice, ecoParticipat
 | stocklevel | number | Indicates the stock level of the product. |
 | minStocklevel | number | Indicates the minimum stock level of the product. Available if the field *Minimum stock level* is used in the administration area of a shop. Only available with the `products_write` authorisation. |
 | links | array of [link](page:apps-data-types#link) | The links to the product and product category. |
+| productVariationType | enum | The type of the variation product. Can be one of *master*, *regular* or *variation*. |
+| productVariationSelection | array of [variationIdentifier](page:apps-data-types#variationidentifier) | The selection of the variation product. Only available if `productVariationType` is *variation*. |
 
 ## product (create request)
 

--- a/apps/data-types.md
+++ b/apps/data-types.md
@@ -381,6 +381,9 @@ This object is used for the attributes of basePrice, depositPrice, ecoParticipat
 | searchKeywords | array of string | The search terms for the product determined by the merchant in the administration. |
 | visible | boolean | Indicates if the product is displayed in the shop. |
 | taxClassId | string | The unique identifier of the tax class. |
+| stocklevel | number | Indicates the stock level of the product. |
+| depositPrice | object of [price](page:apps-data-types#price) | The deposit price for the product, e.g. bottle deposit.|
+| manufacturerPrice | object of [price](page:apps-data-types#price) | The sales price recommended by the manufacturer.|
 
 ## productLineItem
 

--- a/apps/data-types.md
+++ b/apps/data-types.md
@@ -538,6 +538,13 @@ This object is used for the attributes of basePrice, depositPrice, ecoParticipat
 | displayName | string | The displayed name of the variation attribute. |
 | values | array of [variationValue](page:apps-data-types#variationvalue) | The values of the variation attribute.  |
 
+## variationIdentifier
+
+| Attribute | Type | Description |
+| - | :-: |  - |
+| name | string | The name of the selected product variation. |
+| value | string | The value of the selected product variation.  |
+
 ## variationValue
 
 | Attribute | Type | Description |


### PR DESCRIPTION
TW-316

- update examples
- specify the attributes stocklevel, depositPrice, ecoParticipationPrice and manufacturerPrice for POST product
- remove energyLabelsString and ecoParticipationPrice from POST and PATCH calls

TW-317

- update data types
- manufacturerProductNumber (string)
- minStocklevel (number) This should only be included in GET if product_write scope is available
- productLength (number)
- productHeight (number)
- productWidth (number)
- update responses for GET, PATCH and POST product

TW-404

- add attribute `productVariationType` (enum)
- add attribute `productVariationSelection` (array of variationIdentifier)
- add datatype `variationIdentifier` (consists of name and value)
- update all product-related responses

TW-415

-  add attribute minStocklevel to product data type (number)
-  add explanation, that it is only used if the setting "lowStock" is used in the administration area
-  change stocklevel to stock level
-  change string to number
-  remove products write authorisation from stocklevel attribute
-  update responses

@ubep please check and merge