### PR TITLE
Improve side menu

### DIFF
--- a/_includes/sitemap.html
+++ b/_includes/sitemap.html
@@ -4,3 +4,11 @@
     <li class="sitemap-entry">{% sitemap_link entry %}</li>
   {% endfor %}
 {% endfor %}
+
+<script type="text/javascript">
+  document.querySelectorAll('li.sitemap-entry').forEach(function(elem) {
+    if (elem.querySelector('a').getAttribute('href') == window.location.pathname) {
+      elem.className += ' active'
+    }
+  })
+</script>

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -503,7 +503,7 @@ footer .social .xing:hover {
 /* Content Navigation */
 .contentnav {
   float: left;
-  margin-right: 1%;
+  margin-right: 0;
   width: 19%;
   font-size: 16px;
   line-height: 2;

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -523,6 +523,15 @@ footer .social .xing:hover {
   margin-top: 20px;
 }
 
+.sitemap-entry.active {
+  margin-left: -10px;
+  padding-left: 10px;
+  margin-right: 30px;
+  border: 1px solid black;
+  border-radius: 5px;
+  background-color: beige;
+}
+
 /* Content */
 .content-inner {
   float: left;

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -526,10 +526,9 @@ footer .social .xing:hover {
 .sitemap-entry.active {
   margin-left: -10px;
   padding-left: 10px;
-  margin-right: 30px;
-  border: 1px solid black;
-  border-radius: 5px;
-  background-color: beige;
+  border: 1px solid #eee;
+  border-right: 0;
+  background-color: #eee;
 }
 
 /* Content */


### PR DESCRIPTION
Following up on the feedback we gave on Friday regarding the new API-docs, I made a small improvement to the side menu.
It now highlights any active menu item (i.e. the one which points to the current URL).
The improvement is quite generic, and works also on the Blog pages, although it might not have been the prettiest way of implementing it. (The "proper" way possibly being hooking into the static site generation).

While doing this I also noticed that there is a duplicate entry in the API docs (Use Cases).
 