### PR TITLE
Add find-order-confirmation endpoint

### DIFF
--- a/_data/beyond-sidebar.yml
+++ b/_data/beyond-sidebar.yml
@@ -439,8 +439,11 @@
               link: https://api-docs.beyondshop.cloud/ng-order-order-public-api.html#resources-order-get
               id: show_order_details
             - title: Show order by cart ID
-              link: https://api-docs.beyondshop.cloud/ng-order-order-public-api.html#resources-order-get-by-cartid
+              link: https://api-docs.beyondshop.cloud/ng-order-order-public-api.html#resources-order-find-by-cart-id
               id: show_order_by_cart_id
+            - title: Show order confirmation details by cart ID
+              link: https://api-docs.beyondshop.cloud/ng-order-order-public-api.html#resources-find-order-confirmation
+              id: show_order_confirmation_details_by_cart_id
             - title: Show order number and order ID by cart ID
               link: https://api-docs.beyondshop.cloud/ng-order-order-public-api.html#resources-find-order-number-by-cart-id
               id: show_order_number_and_order_id_by_cart_id


### PR DESCRIPTION
Added `find-order-confirmation` endpoint in `Orders`
(& renamed older resource `order-find-by-cart-id`).
Ref PR: https://github.com/ePages-de/ng-order/pull/1125