### PR TITLE
EPNG-8960: Removing the find-by-label endpoint

### DIFF
--- a/_data/beyond-sidebar.yml
+++ b/_data/beyond-sidebar.yml
@@ -1024,9 +1024,6 @@
             - title: Search matching product categories for product
               link: https://api-docs.beyondshop.cloud/ng-product-view-product-view-public-api.html#categories-find-by-product
               id: search_matching_product_categories_for_product
-            - title: Find product category by label
-              link: https://api-docs.beyondshop.cloud/ng-product-view-product-view-public-api.html#categories-find-by-label
-              id: find_product_category_by_label
             - title: Preview products included in category
               link: https://api-docs.beyondshop.cloud/ng-product-view-product-view-public-api.html#categories-products-preview
               id: preview_products_included_in_category


### PR DESCRIPTION
The endpoint /product-view/categories/search/find-by-label was removed.
It also needs to be removed from the sidebar... it's currently broken.