### PR TITLE
Link to BYD webhook-subscriptions introduction in sidebar

### DIFF
--- a/_data/beyond-sidebar.yml
+++ b/_data/beyond-sidebar.yml
@@ -1247,6 +1247,9 @@
       entries:
         - title: Webhook subscriptions
           entries:
+            - title: Introduction
+              link: https://api-docs.beyondshop.cloud/ng-webhook-webhook-public-api.html#resources-subscriptions
+              id: webhook_subscriptions_introduction
             - title: Create webhook subscription
               link: https://api-docs.beyondshop.cloud/ng-webhook-webhook-public-api.html#resources-subscription-create
               id: create_webhook_subscription


### PR DESCRIPTION
Currently, the introduction section with event types and retry policy is not accessible via navigation, but one needs to know to "scroll up" on the first menu entry to reach this info. This PR attempts to improve this by adding an "Introduction" section.

![Peek 2022-11-29 13-46](https://user-images.githubusercontent.com/16290998/204533066-6f63018b-1f69-46ce-ae57-34fa4c2514b6.gif)
