### PR TITLE
Adjusts date of change log entry Dec 5

### DIFF
--- a/apps/change-log.md
+++ b/apps/change-log.md
@@ -14,7 +14,7 @@ Of course, we will continue to inform you if there are any breaking changes to t
 
 <hr>
 
-## 2022-11-03
+## 2022-12-06
 
 ### Changes with software release 7.77.0
 


### PR DESCRIPTION
Since the changes from `develop-docs` could only be merged into `master` after the new version had been rolled out, the date of the change log entry needs to be adapted.